### PR TITLE
Fixes for JS/C++ message handling.

### DIFF
--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -716,5 +716,5 @@ $(document).ready(function () {
         UiDriver.handleMessageInternally("J_EVT_GOT_FOCUS");
     });
 
-    UiDriver.sendMessage("J_EVT_READY", null);
+    UiDriver.sendMessage("J_EVT_READY", null); //This one needs to be sendMessage() because the C++ Editor picks up that signal.
 });

--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -15,7 +15,7 @@ UiDriver.registerEventHandler("C_FUN_GET_VALUE", function(msg, data, prevReturn)
    You'll generally want to use this function instead of
    CodeMirror.isClean()
 */
- function isCleanOrForced(generation) {
+function isCleanOrForced(generation) {
     return !forceDirty && editor.isClean(generation);
 }
 
@@ -146,7 +146,6 @@ UiDriver.registerEventHandler("C_FUN_GET_LINE_COUNT", function(msg, data, prevRe
 
 UiDriver.registerEventHandler("C_FUN_GET_CURSOR", function(msg, data, prevReturn) {
     var cur = editor.getCursor();
-    //UiDriver.setReturnData([cur.line, cur.ch]);
     return [cur.line, cur.ch];
     
 });

--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -15,19 +15,23 @@ UiDriver.registerEventHandler("C_FUN_GET_VALUE", function(msg, data, prevReturn)
    You'll generally want to use this function instead of
    CodeMirror.isClean()
 */
-function isCleanOrForced(generation) {
+ function isCleanOrForced(generation) {
     return !forceDirty && editor.isClean(generation);
 }
 
 UiDriver.registerEventHandler("C_CMD_MARK_CLEAN", function(msg, data, prevReturn) {
     forceDirty = false;
     changeGeneration = editor.changeGeneration(true);
-    UiDriver.sendMessage("J_EVT_CLEAN_CHANGED", isCleanOrForced(changeGeneration));
+    
+
+    UiDriver.handleMessageInternally("J_EVT_CLEAN_CHANGED", isCleanOrForced(changeGeneration));
+
+    
 });
 
 UiDriver.registerEventHandler("C_CMD_MARK_DIRTY", function(msg, data, prevReturn) {
     forceDirty = true;
-    UiDriver.sendMessage("J_EVT_CLEAN_CHANGED", isCleanOrForced(changeGeneration));
+    UiDriver.handleMessageInternally("J_EVT_CLEAN_CHANGED", isCleanOrForced(changeGeneration));
 });
 
 UiDriver.registerEventHandler("C_FUN_IS_CLEAN", function(msg, data, prevReturn) {
@@ -146,7 +150,9 @@ UiDriver.registerEventHandler("C_FUN_GET_LINE_COUNT", function(msg, data, prevRe
 
 UiDriver.registerEventHandler("C_FUN_GET_CURSOR", function(msg, data, prevReturn) {
     var cur = editor.getCursor();
-    UiDriver.setReturnData([cur.line, cur.ch]);
+    //UiDriver.setReturnData([cur.line, cur.ch]);
+    return [cur.line, cur.ch];
+    
 });
 
 UiDriver.registerEventHandler("C_CMD_SET_CURSOR", function(msg, data, prevReturn) {
@@ -707,7 +713,7 @@ $(document).ready(function () {
     });
 
     editor.on("focus", function() {
-        UiDriver.sendMessage("J_EVT_GOT_FOCUS");
+        UiDriver.handleMessageInternally("J_EVT_GOT_FOCUS");
     });
 
     UiDriver.sendMessage("J_EVT_READY", null);

--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -704,12 +704,12 @@ $(document).ready(function () {
     changeGeneration = editor.changeGeneration(true);
 
     editor.on("change", function(instance, changeObj) {
-        UiDriver.sendMessage("J_EVT_CONTENT_CHANGED");
-        UiDriver.sendMessage("J_EVT_CLEAN_CHANGED", isCleanOrForced(changeGeneration));
+        UiDriver.handleMessageInternally("J_EVT_CONTENT_CHANGED");
+        UiDriver.handleMessageInternally("J_EVT_CLEAN_CHANGED", isCleanOrForced(changeGeneration));
     });
 
     editor.on("cursorActivity", function(instance, changeObj) {
-        UiDriver.sendMessage("J_EVT_CURSOR_ACTIVITY");
+        UiDriver.handleMessageInternally("J_EVT_CURSOR_ACTIVITY");
     });
 
     editor.on("focus", function() {

--- a/src/editor/app.js
+++ b/src/editor/app.js
@@ -22,11 +22,7 @@ UiDriver.registerEventHandler("C_FUN_GET_VALUE", function(msg, data, prevReturn)
 UiDriver.registerEventHandler("C_CMD_MARK_CLEAN", function(msg, data, prevReturn) {
     forceDirty = false;
     changeGeneration = editor.changeGeneration(true);
-    
-
     UiDriver.handleMessageInternally("J_EVT_CLEAN_CHANGED", isCleanOrForced(changeGeneration));
-
-    
 });
 
 UiDriver.registerEventHandler("C_CMD_MARK_DIRTY", function(msg, data, prevReturn) {

--- a/src/editor/classes/Languages.js
+++ b/src/editor/classes/Languages.js
@@ -1120,7 +1120,7 @@ var Languages = new function() {
             editor.setOption("foldGutter", true);
         }
 
-        UiDriver.sendMessage("J_EVT_CURRENT_LANGUAGE_CHANGED", {id: languageId, name: lang.name});
+        UiDriver.handleMessageInternally("J_EVT_CURRENT_LANGUAGE_CHANGED", {id: languageId, name: lang.name});
     }
     
     this.currentLanguage = function() {

--- a/src/editor/classes/UiDriver.js
+++ b/src/editor/classes/UiDriver.js
@@ -98,13 +98,6 @@ var UiDriver = new function() {
             console.error("Not using QtWebChannel: "+ msg);
             data = cpp_ui_driver.getMsgData();
         }
-        
-        /*if(msg == "C_CMD_SET_VALUE") {
-            console.error("Killing this execution.");
-            channel.objects.cpp_ui_driver.makeReplyReady();
-            return null;
-        }*/
-        
 
         // Only one of the handlers (the last that gets
         // called) can return a value. So, to each handler
@@ -124,8 +117,6 @@ var UiDriver = new function() {
         if(prevReturn !== undefined) {
             console.error("Setting return data for: "+ msg);
             _this.setReturnData(prevReturn);
-            //channel.objects.cpp_ui_driver.makeReplyReady();
-            //channel.objects.cpp_ui_driver.m_result = "";
         }else {
             console.error("Making reply for: "+ msg);
             channel.objects.cpp_ui_driver.makeReplyReady();

--- a/src/editor/classes/UiDriver.js
+++ b/src/editor/classes/UiDriver.js
@@ -99,11 +99,11 @@ var UiDriver = new function() {
             data = cpp_ui_driver.getMsgData();
         }
         
-        if(msg == "C_CMD_SET_VALUE") {
+        /*if(msg == "C_CMD_SET_VALUE") {
             console.error("Killing this execution.");
             channel.objects.cpp_ui_driver.makeReplyReady();
             return null;
-        }
+        }*/
         
 
         // Only one of the handlers (the last that gets

--- a/src/editor/classes/UiDriver.js
+++ b/src/editor/classes/UiDriver.js
@@ -82,9 +82,7 @@ var UiDriver = new function() {
         console.error("Received internal message: "+ msg);
 
         if (handlers[msg] !== undefined) {
-            
             console.error("Defined handlers[msg] has " + handlers[msg].length + ": " + msg);
-        
             handlers[msg].forEach(function(handler) {
                 console.error("Foreach: "+ handler);
             });
@@ -105,9 +103,7 @@ var UiDriver = new function() {
         var prevReturn = undefined;
 
         if (handlers[msg] !== undefined) {
-            
             console.error("Defined handlers[msg] has " + handlers[msg].length + ": " + msg);
-        
             handlers[msg].forEach(function(handler) {
                 console.error("Foreach: "+ handler);
                 prevReturn = handler(msg, data, prevReturn);

--- a/src/editor/classes/UiDriver.js
+++ b/src/editor/classes/UiDriver.js
@@ -77,12 +77,34 @@ var UiDriver = new function() {
         channel.objects.cpp_ui_driver.makeReplyReady();
         channel.objects.cpp_ui_driver.m_result = "";
     }
+    
+    this.handleMessageInternally = function(msg, data) {
+        console.error("Received internal message: "+ msg);
+
+        if (handlers[msg] !== undefined) {
+            
+            console.error("Defined handlers[msg] has " + handlers[msg].length + ": " + msg);
+        
+            handlers[msg].forEach(function(handler) {
+                console.error("Foreach: "+ handler);
+            });
+        }
+ 
+    }
 
     this.messageReceived = function(msg, data) {
         console.error("Received message: "+ msg);
         if (!usingQtWebChannel()) {
+            console.error("Not using QtWebChannel: "+ msg);
             data = cpp_ui_driver.getMsgData();
         }
+        
+        if(msg == "C_CMD_SET_VALUE") {
+            console.error("Killing this execution.");
+            channel.objects.cpp_ui_driver.makeReplyReady();
+            return null;
+        }
+        
 
         // Only one of the handlers (the last that gets
         // called) can return a value. So, to each handler
@@ -90,13 +112,22 @@ var UiDriver = new function() {
         var prevReturn = undefined;
 
         if (handlers[msg] !== undefined) {
+            
+            console.error("Defined handlers[msg] has " + handlers[msg].length + ": " + msg);
+        
             handlers[msg].forEach(function(handler) {
+                console.error("Foreach: "+ handler);
                 prevReturn = handler(msg, data, prevReturn);
             });
         }
+        
         if(prevReturn !== undefined) {
+            console.error("Setting return data for: "+ msg);
             _this.setReturnData(prevReturn);
+            //channel.objects.cpp_ui_driver.makeReplyReady();
+            //channel.objects.cpp_ui_driver.m_result = "";
         }else {
+            console.error("Making reply for: "+ msg);
             channel.objects.cpp_ui_driver.makeReplyReady();
         }
         return prevReturn;

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -91,7 +91,7 @@ namespace EditorNS
         m_layout->addWidget(m_webView, 1);
         setLayout(m_layout);
 #ifdef USE_QTWEBENGINE
-		connect(m_webView->page(),
+        connect(m_webView->page(),
                 &QWebEnginePage::loadFinished,
                 this,
                 &Editor::on_javaScriptWindowObjectCleared);
@@ -148,7 +148,7 @@ namespace EditorNS
     void Editor::waitAsyncLoad()
     {
         if (!m_loaded) {
-			qDebug() << "Not yet loaded, wait async.";
+            qDebug() << "Not yet loaded, wait async.";
             QEventLoop loop;
             connect(this, &Editor::editorReady, &loop, &QEventLoop::quit);
             // Block until a J_EVT_READY message is received
@@ -403,32 +403,18 @@ namespace EditorNS
 
     QVariant Editor::sendMessageWithResult(const QString &msg, const QVariant &data)
     {
-		//if(msg.startsWith("C_CMD_SET_") || msg.startsWith("C_FUN_SET") || msg.startsWith("C_FUN_DETECT")) {
-		//	return QString("0");
-			//qDebug() << "here";
-		//}
+        qDebug() << "Creating lock for: " << msg;
 
-		qDebug() << "Creating lock for: " << msg;
-
-		//QMutexLocker locker(&m_processMutex);
-		bool locked = m_processMutex.tryLock(-1000);
-
-		if(!locked) qDebug() << "Not locked for messsage:" << msg;
-
+        QMutexLocker locker(&m_processMutex);
         waitAsyncLoad();
+
         QEventLoop l;
         connect(m_jsToCppProxy, &JsToCppProxy::replyReady, &l, &QEventLoop::quit, Qt::DirectConnection);
-
-		/*QTimer t;
-		connect(&t, &QTimer::timeout, &l, &QEventLoop::quit, Qt::DirectConnection);
-		t.start(1000);*/
-
         emit m_jsToCppProxy->sendMsg(jsStringEscape(msg), makeMessageData(data));
+
         qDebug() << "Waiting on Reply for: " << msg;
         l.exec();
-		qDebug() << "Finished waiting for:" << msg;
-
-		m_processMutex.unlock();
+        qDebug() << "Finished waiting for:" << msg;
 
         return m_jsToCppProxy->getResult();
     }

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -10,7 +10,6 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
-#include <QTimer>
 
 #ifdef USE_QTWEBENGINE
     #include <QWebEngineSettings>

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -48,7 +48,7 @@ namespace EditorNS
         Q_INVOKABLE QVariant getResult() { return m_result; }
         void setResult(QVariant data) { m_result = data;}
         void resetResult() {}
-        Q_PROPERTY(QVariant m_result READ getResult WRITE setResult NOTIFY replyReady RESET resetResult);
+		Q_PROPERTY(QVariant m_result READ getResult WRITE setResult NOTIFY replyReady RESET resetResult)
     public slots:
         Q_INVOKABLE void receiveMessage(QString msg, QVariant data) {
             emit messageReceived(msg, data);

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -48,7 +48,7 @@ namespace EditorNS
         Q_INVOKABLE QVariant getResult() { return m_result; }
         void setResult(QVariant data) { m_result = data;}
         void resetResult() {}
-		Q_PROPERTY(QVariant m_result READ getResult WRITE setResult NOTIFY replyReady RESET resetResult)
+        Q_PROPERTY(QVariant m_result READ getResult WRITE setResult NOTIFY replyReady RESET resetResult)
     public slots:
         Q_INVOKABLE void receiveMessage(QString msg, QVariant data) {
             emit messageReceived(msg, data);
@@ -353,7 +353,7 @@ namespace EditorNS
         void editorReady();
 
         void currentLanguageChanged(QString id, QString name);
-       
+
     public slots:
         void sendMessage(const QString &msg, const QVariant &data);
         void sendMessage(const QString &msg);


### PR DESCRIPTION
I got it to open and kind of show content.

Since this is mostly about understanding how all of this works, I'll detail my progress here instead of just posting my changes:

First thing that came to my attention is that the C++ code expects different message results than the JS code returns. Here's what the dbg messages used to say:

```
Creating lock for:  "C_CMD_SET_VALUE"
Waiting on Reply for:  "C_CMD_SET_VALUE"
js: Received message: C_CMD_SET_SMART_INDENT
js: Setting return data to: true
Finished waiting for: "C_CMD_SET_VALUE"
```

The C++ loop is waiting for `SET_VALUE` but JS executes the previous  command (in this case `SMART_INDENT`).

This desync starts with the first call to `C_FUN_GET_CURSOR`  because of how its implementation changed:

```
UiDriver.registerEventHandler("C_FUN_GET_CURSOR", function(msg, data, prevReturn) {
    var cur = editor.getCursor();
    UiDriver.setReturnData([cur.line, cur.ch]); //new way
    //return [cur.line, cur.ch]; //<- old way
});
```
`setReturnData` calls `channel.objects.cpp_ui_driver.makeReplyReady();` which signals to the C++ code that the operation has finished. C++ then runs some more code and calls the next sendMessageWithResult call. At this point, JS picks up code execution again, continues with handling the *old* message and ultimately calling `_this.setReturnData(prevReturn);` again. At that point, each call to `sendMessageWithResult` returns the result of the previous call.

I fixed that by reverting back to `return [cur.line, cur.ch];`.

Next up, `C_CMD_MARK_CLEAN` broke message handling because its handler calls `UiDriver.sendMessage("J_EVT_CLEAN_CHANGED", isCleanOrForced(changeGeneration));` from inside JS. But since the JS doesn't differentiate between `sendMessage()` calls from C++ and JS, we emit another ready signal that C++ picks up. That problem pops up a ton of times in different message handlers. To fix that, I added a `handleMessageInternally` to `UiDriver` that simply calls all handlers and returns. 

After that, Nqq starts again. Huzzah! 

A bunch of things are still broken, such as linebreaks, syntax coloring, etc.