### PR TITLE
Add a throw to inform devs of a QEventLoop contention issue.

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -367,6 +367,9 @@ namespace EditorNS
 
     QVariant Editor::sendMessageWithResult(const QString &msg, const QVariant &data)
     {
+        if(m_processLoop.isRunning())
+            throw std::runtime_error("m_processLoop must never be running at this point. Did this function get called from another thread?");
+
         emit m_jsToCppProxy->sendMsg(jsStringEscape(msg), data);
         m_processLoop.exec();
         return m_jsToCppProxy->getResult();


### PR DESCRIPTION
This throw gets triggered by *some* of the move-tabs-around crashes but not all of them. I think there is probably more than failure point around. 

Either way, if m_processLoop is already running *something* went wrong in a bad way and it's best to just throw. At least we know what and where it happened.