### PR TITLE
Remove backslash so Qmake doesn't think QMAKE_DISTCLEAN is a subproject.

### DIFF
--- a/notepadqq.pro
+++ b/notepadqq.pro
@@ -1,4 +1,4 @@
 TEMPLATE = subdirs
-SUBDIRS = src/ui \
+SUBDIRS = src/ui
 #    src/ui-tests
 QMAKE_DISTCLEAN += Makefile && rm -rf out


### PR DESCRIPTION
Can't compile otherwise.