### PR TITLE
Setting page background to transparent reduces the white flash issue.

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -51,6 +51,7 @@ namespace EditorNS
         m_webView->connectJavaScriptObject("cpp_ui_driver", m_jsToCppProxy);
         
         m_webView->page()->load(url);
+        m_webView->page()->setBackgroundColor(Qt::transparent);
 
         initContextMenu();
         


### PR DESCRIPTION
It doesn't eliminate it but it's a little better. Maybe one of the injected files (app.js, app.css, init.js, ...) tries to set the background color to white before the theme comes into effect? That would explain why this patch doesn't completely resolve the problem.