### PR TITLE
Fix #384, also fixed an issue with onEditorChanged not being called.

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -186,7 +186,8 @@ namespace EditorNS
         {
             // Data should be context aware of when the file was loaded
             // later on
-            emit documentLoaded(false);
+            emit documentLoaded(m_alreadyLoaded);
+            m_alreadyLoaded = true;
         }
     }
 

--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -184,8 +184,6 @@ namespace EditorNS
             emit currentLanguageChanged(id, name);
         }else if(msg == "J_EVT_DOCUMENT_LOADED")
         {
-            // Data should be context aware of when the file was loaded
-            // later on
             emit documentLoaded(m_alreadyLoaded);
             m_alreadyLoaded = true;
         }

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -284,6 +284,7 @@ namespace EditorNS
         QTextCodec *m_codec = QTextCodec::codecForName("UTF-8");
         bool m_bom = false;
         bool m_customIndentationMode = false;
+        bool m_alreadyLoaded = false;
 
         inline void waitAsyncLoad();
         QString jsStringEscape(QString str) const;

--- a/src/ui/include/topeditorcontainer.h
+++ b/src/ui/include/topeditorcontainer.h
@@ -48,6 +48,7 @@ public:
 
 private:
     EditorTabWidget *m_currentTabWidget;
+    int m_currentTabIndex = -1;
 
 signals:
     /**

--- a/src/ui/topeditorcontainer.cpp
+++ b/src/ui/topeditorcontainer.cpp
@@ -89,9 +89,10 @@ void TopEditorContainer::on_currentTabChanged(int index)
     if (!tabWidget)
         return;
 
-    if (m_currentTabWidget == tabWidget && m_currentTabWidget->currentIndex() == index)
+    if (m_currentTabWidget == tabWidget && m_currentTabIndex == index)
         return;
 
+    m_currentTabIndex = index;
     m_currentTabWidget = tabWidget;
     emit currentTabChanged(tabWidget, index);
     emit currentEditorChanged(tabWidget, index);


### PR DESCRIPTION
Added a member variable to keep track of whether the file was loaded for the first time or reloaded. That fixes the indentation banner reappearing on reload.

Also, a previous patch of mine introduced a bug. Details below.

PS: Also fixes #379 I believe.