### PR TITLE
Fix load order of init.js

### DIFF
--- a/src/editor/index.html
+++ b/src/editor/index.html
@@ -5,15 +5,18 @@
     <title>Notepadqq</title>
     <script src="qrc:///qtwebchannel/qwebchannel.js"></script>
 
-    <script src="init.js"></script>
     <script src="classes/UiDriver.js"></script>
     <script src="classes/EditorStatusEvents.js"></script>
     <script src="libs/jquery/jquery.min.js"></script>
     <script src="libs/codemirror/lib/codemirror.js"></script>
+	     
     <link rel="stylesheet" href="libs/codemirror/lib/codemirror.css">
     <link rel="stylesheet" href="libs/codemirror/addon/fold/foldgutter.css">
     <link rel="stylesheet" href="libs/codemirror/addon/hint/show-hint.css">
 
+    <!-- requires libs/.../codemirror.css to be loaded -->
+    <script src="init.js"></script>
+	  
     <!-- MODES -->
     <script src="libs/codemirror/mode/apl/apl.js"></script>
     <script src="libs/codemirror/mode/asciiarmor/asciiarmor.js"></script>


### PR DESCRIPTION
Loading themes breaks if codemirror.css is not yet loaded.

Relevant: https://github.com/notepadqq/notepadqq/pull/373#issuecomment-285949744

**Edit:** Obsolete. Do not merge.