### PR TITLE
Remove SET_FOCUS message and call setFocus() on tab switches.

### DIFF
--- a/src/ui/EditorNS/editor.cpp
+++ b/src/ui/EditorNS/editor.cpp
@@ -187,15 +187,11 @@ namespace EditorNS
     void Editor::setFocus()
     {
         m_webView->setFocus();
-        asyncSendMessageWithResultP("C_CMD_SET_FOCUS");
     }
 
-    void Editor::clearFocus(bool widgetOnly)
+    void Editor::clearFocus()
     {
         m_webView->clearFocus();
-        if (!widgetOnly) {
-            asyncSendMessageWithResultP("C_CMD_BLUR");
-        }
     }
 
     /**

--- a/src/ui/Sessions/sessions.cpp
+++ b/src/ui/Sessions/sessions.cpp
@@ -464,7 +464,7 @@ void loadSession(DocEngine* docEngine, TopEditorContainer* editorContainer, QStr
             }
 
             // loadDocuments() explicitly calls setFocus() so we'll have to undo that.
-            editor->clearFocus(true);
+            editor->clearFocus();
         } // end for
 
         // In case a new tabwidget was created but no tabs were actually added to it,

--- a/src/ui/include/EditorNS/editor.h
+++ b/src/ui/include/EditorNS/editor.h
@@ -152,7 +152,7 @@ namespace EditorNS
              *
              * @param widgetOnly only clear the focus on the actual widget
              */
-        Q_INVOKABLE void clearFocus(bool widgetOnly = false);
+        Q_INVOKABLE void clearFocus();
 
         /**
              * @brief Set the file name associated with this editor

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1187,6 +1187,7 @@ void MainWindow::on_currentEditorChanged(EditorTabWidget *tabWidget, int tab)
         Editor *editor = tabWidget->editor(tab);
         refreshEditorUiInfo(editor);
         editor->requestDocumentInfo();
+        editor->setFocus();
     }
 }
 


### PR DESCRIPTION
There's a regression with document focus that's in this branch and in current master.

Open two documents side-by-side. Switching the active editor by clicking on the tab bar doesn't move the active focus (aka the blinking caret) to the clicked tab.

That seems properly fixed by calling `setFocus` in the `onEditorChanged()` callback.

Then I also removed the async stuff called during focus events. I couldn't find anything wrong with this. Can you check it out?